### PR TITLE
Removing deprecation warning from asyncio.wait in advanced websockets example

### DIFF
--- a/6_asyncio_websockets/advance_websocket.py
+++ b/6_asyncio_websockets/advance_websocket.py
@@ -26,13 +26,13 @@ def users_status():
 async def notify_counter_state():
     if USERS:  # asyncio.wait doesn't accept an empty list
         message = counter_status()
-        await asyncio.wait([user.send(message) for user in USERS])
+        await asyncio.wait([asyncio.create_task(user.send(message)) for user in USERS])
 
 
 async def notify_users():
     if USERS:  # asyncio.wait doesn't accept an empty list
         message = users_status()
-        await asyncio.wait([user.send(message) for user in USERS])
+        await asyncio.wait([asyncio.create_task(user.send(message)) for user in USERS])
 
 
 async def register(websocket):


### PR DESCRIPTION
## Additions

- None

## Removals

- None

## Changes

- `advance_websocket.py`: adding `asyncio.create_task()` fixes deprecation warning `"DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait()`. Based on [official docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.wait) this will be removed in version 3.11.

## Testing Steps

- run `advance_websocket.py` along with `advance_client.html` and play with the app. no warning should appear no longer.


## Notes

- I was running the examples with Python 3.9.10 and these warnings were observed there
- Running with Python 3.10 was adding additional warnings and wasn't working at all, submitted an issue https://github.com/kave/asyncio-examples/issues/3 to fix this